### PR TITLE
fix: button colors

### DIFF
--- a/app/src/main/java/net/youapps/calcyou/ui/components/Keypad.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/components/Keypad.kt
@@ -64,8 +64,8 @@ fun CenterKeypad(
         ) {
             CalculatorButton(
                 text = "⌫",
-                backgroundColor = MaterialTheme.colorScheme.tertiary,
-                textColor = MaterialTheme.colorScheme.onTertiary,
+                backgroundColor = MaterialTheme.colorScheme.tertiaryContainer,
+                textColor = MaterialTheme.colorScheme.onTertiaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Delete)
                 },
@@ -76,8 +76,8 @@ fun CenterKeypad(
 
             CalculatorButton(
                 text = SpecialOperator.Bracket.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.SpecialOperator(SpecialOperator.Bracket))
                 }
@@ -85,8 +85,8 @@ fun CenterKeypad(
 
             CalculatorButton(
                 text = SimpleOperator.Percent.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Operator(SimpleOperator.Percent))
                 }
@@ -94,8 +94,8 @@ fun CenterKeypad(
 
             CalculatorButton(
                 text = SimpleOperator.Divide.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Operator(SimpleOperator.Divide))
                 }
@@ -126,8 +126,8 @@ fun CenterKeypad(
             )
             CalculatorButton(
                 text = SimpleOperator.Multiply.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Operator(SimpleOperator.Multiply))
                 }
@@ -158,8 +158,8 @@ fun CenterKeypad(
             )
             CalculatorButton(
                 text = SimpleOperator.Minus.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Operator(SimpleOperator.Minus))
                 }
@@ -190,8 +190,8 @@ fun CenterKeypad(
             )
             CalculatorButton(
                 text = SimpleOperator.Plus.text,
-                backgroundColor = MaterialTheme.colorScheme.secondary,
-                textColor = MaterialTheme.colorScheme.onSecondary,
+                backgroundColor = MaterialTheme.colorScheme.secondaryContainer,
+                textColor = MaterialTheme.colorScheme.onSecondaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Operator(SimpleOperator.Plus))
                 }
@@ -222,8 +222,8 @@ fun CenterKeypad(
             )
             CalculatorButton(
                 text = "=",
-                backgroundColor = MaterialTheme.colorScheme.primary,
-                textColor = MaterialTheme.colorScheme.onPrimary,
+                backgroundColor = MaterialTheme.colorScheme.primaryContainer,
+                textColor = MaterialTheme.colorScheme.onPrimaryContainer,
                 onClick = {
                     onEvent(CalculatorEvent.Evaluate)
                 }

--- a/app/src/main/java/net/youapps/calcyou/ui/components/buttons/CalculatorButton.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/components/buttons/CalculatorButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,12 +20,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun RowScope.CalculatorButton(
     text: String,
-    textColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
-    backgroundColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    backgroundColor: Color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
     aspectRatio: Float = 1f,
     onClick: () -> Unit,
     onLongClick: () -> Unit = { },
@@ -50,7 +52,7 @@ fun RowScope.CalculatorButton(
     aspectRatio: Float = 1f,
     onClick: () -> Unit,
     onLongClick: () -> Unit = { },
-    content: @Composable() (BoxScope.() -> Unit)
+    content: @Composable (BoxScope.() -> Unit)
 ) {
     val view = LocalView.current
     val haptic = LocalHapticFeedback.current

--- a/app/src/main/java/net/youapps/calcyou/ui/components/buttons/CalculatorTextButton.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/components/buttons/CalculatorTextButton.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.platform.LocalView
 @Composable
 fun RowScope.CalculatorTextButton(
     text: String,
-    textColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
     aspectRatio: Float = 1f,
     onClick: () -> Unit,
     onLongClick: () -> Unit = { }


### PR DESCRIPTION
This makes the button colors match G-Calc.

| Before | After |
| --- | --- |
| ![signal-2023-11-09-125116_002](https://github.com/you-apps/CalcYou/assets/82398591/1ea7a0d3-2269-473b-971b-03b446686261) | ![signal-2023-11-09-125020_003](https://github.com/you-apps/CalcYou/assets/82398591/93f7a828-378d-41e6-a3a3-c693ecdf92b1) |

## G-Calc:
<img src="https://github.com/you-apps/CalcYou/assets/82398591/212ae72b-a138-4e2f-ae94-111ecbdb4a08" width="50%">


