### PR TITLE
style: change character input screen colors

### DIFF
--- a/app/src/main/java/net/youapps/calcyou/ui/components/buttons/KeyboardKey.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/components/buttons/KeyboardKey.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,7 +29,7 @@ fun KeyboardKey(
     Box(
         modifier = Modifier
             .clip(shape = RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.primaryContainer)
+            .background(MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp))
             .size(48.dp)
             .clickable {
                 onClick()
@@ -41,7 +42,7 @@ fun KeyboardKey(
             Modifier
                 .padding(4.dp),
             style = MaterialTheme.typography.headlineSmall,
-            color = MaterialTheme.colorScheme.onPrimaryContainer
+            color = MaterialTheme.colorScheme.onSurface
 
         )
     }
@@ -77,7 +78,7 @@ fun KeyboardSpecialKey(
                 keyboardKey,
                 Modifier
                     .padding(vertical = 4.dp, horizontal = 16.dp),
-                style = MaterialTheme.typography.headlineSmall,
+                style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
         }

--- a/app/src/main/java/net/youapps/calcyou/ui/screens/CharacterInputScreen.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/screens/CharacterInputScreen.kt
@@ -58,8 +58,8 @@ fun CharacterInputScreen() {
             textStyle = MaterialTheme.typography.displaySmall,
             modifier = Modifier.fillMaxWidth(),
             colors = TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                unfocusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
                 disabledContainerColor = Color.Transparent,
                 focusedIndicatorColor = Color.Transparent,
                 unfocusedIndicatorColor = Color.Transparent,
@@ -73,7 +73,7 @@ fun CharacterInputScreen() {
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(10.dp)
-                .size(70.dp, 6.dp)
+                .size(70.dp, 4.dp)
                 .clip(RoundedCornerShape(50))
         )
         val rowScrollState = rememberScrollState()

--- a/app/src/main/java/net/youapps/calcyou/ui/screens/CharacterInputScreen.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/screens/CharacterInputScreen.kt
@@ -58,7 +58,7 @@ fun CharacterInputScreen() {
             textStyle = MaterialTheme.typography.displaySmall,
             modifier = Modifier.fillMaxWidth(),
             colors = TextFieldDefaults.colors(
-                focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
                 unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
                 disabledContainerColor = Color.Transparent,
                 focusedIndicatorColor = Color.Transparent,


### PR DESCRIPTION
Small change to the color mapping to match the new style of the converter grid screen.