### PR TITLE
refactor(storage converter): use decimal units instead of binary prefixes

### DIFF
--- a/app/src/main/java/net/youapps/calcyou/data/converters/DigitalStorageConverter.kt
+++ b/app/src/main/java/net/youapps/calcyou/data/converters/DigitalStorageConverter.kt
@@ -6,17 +6,17 @@ class DigitalStorageConverter : UnitConverter {
     override val units: List<ConverterUnit> = listOf(
         FactorUnit(R.string.bit, 1.0),
         FactorUnit(R.string._byte, 8.0),
+        FactorUnit(R.string.kilobit, 1E3),
         FactorUnit(R.string.kilobyte, 8E3),
-        FactorUnit(R.string.kibibyte, 8.0 * 1024),
+        FactorUnit(R.string.megabit, 1E6),
         FactorUnit(R.string.megabyte, 8E6),
-        FactorUnit(R.string.mebibyte, 8.0 * 1024 * 1024),
+        FactorUnit(R.string.gigabit, 1E9),
         FactorUnit(R.string.gigabyte, 8E9),
-        FactorUnit(R.string.gigibyte, 8.0 * 1024 * 1024 * 1024),
+        FactorUnit(R.string.terabit, 1E12),
         FactorUnit(R.string.terabyte, 8E12),
-        FactorUnit(R.string.tebibyte, 8.0 * 1024 * 1024 * 1024 * 1024),
+        FactorUnit(R.string.petabit, 1E15),
         FactorUnit(R.string.petabyte, 8E15),
-        FactorUnit(R.string.pebibyte, 8.0 * 1024 * 1024 * 1024 * 1024 * 1024),
+        FactorUnit(R.string.exabit, 1E18),
         FactorUnit(R.string.exabyte, 8E18),
-        FactorUnit(R.string.exbibyte, 8.0 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024)
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,10 +148,10 @@
     <string name="grams_of_fat">Grams of Fat</string>
     <string name="grams_of_protein">Grams of Protein</string>
     <string name="copy_text">Copy Text</string>
-    <string name="kibibyte">KibiByte</string>
-    <string name="mebibyte">MebiByte</string>
-    <string name="gigibyte">GigiByte</string>
-    <string name="tebibyte">TebiByte</string>
-    <string name="pebibyte">PebiByte</string>
-    <string name="exbibyte">ExbiByte</string>
+    <string name="kilobit">Kilobit</string>
+    <string name="megabit">Megabit</string>
+    <string name="gigabit">Gigabit</string>
+    <string name="terabit">Terabit</string>
+    <string name="petabit">Petabit</string>
+    <string name="exabit">Exabit</string>
 </resources>


### PR DESCRIPTION
`bits` are part of the international System of units and frequently used as measurement for internet speed by your ISP or MNO. They are the most common unit of digital information besides `bytes`. Binary prefixes like `kibi` on the other hand are not part of the decimal system and rarely ever used. I think they should be dropped in favor of `bits`. We could also offer both, but this will just cause confusion among users and make the list even longer, so I think this PR is a good solution.