### PR TITLE
fix: remove unused string that causes error

### DIFF
--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -5,7 +5,6 @@
     <string name="mass">Маса</string>
     <string name="calculator">Калькулятор</string>
     <string name="value">Значення</string>
-    <string name="digital_storage">Цифрова пам\'ять</string>
     <string name="frequency">Частота</string>
     <string name="area">Площа</string>
     <string name="unit">Одиниця виміру</string>


### PR DESCRIPTION
This string was renamed from `digital_storage` to `storage`. In this language the old string still exists, which causes an error when generating the APK. This PR removes the duplicate string.