### PR TITLE
Create workflow to create unsigned release apk

### DIFF
--- a/.github/workflows/unsigned_release.yml
+++ b/.github/workflows/unsigned_release.yml
@@ -1,0 +1,29 @@
+name: Create Unsigned Release APK
+
+on:
+  workflow_dispatch:
+
+jobs:
+  debug-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v2
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: "temurin"
+
+      - name: Build APK
+        run: bash ./gradlew assembleRelease --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app
+          path: app/build/outputs/apk/release/*.apk


### PR DESCRIPTION
This makes it very easy and to create release apks. This only creates an unsigned apk and we still have to sign it with our key.
Also the build created by this method was reproducible via F-droid