### PR TITLE
Fix typo in MathUtil docs and apply modifier in landscape

### DIFF
--- a/app/src/main/java/net/youapps/calcyou/data/evaluator/MathUtil.kt
+++ b/app/src/main/java/net/youapps/calcyou/data/evaluator/MathUtil.kt
@@ -42,7 +42,7 @@ object MathUtil {
      *
      * @param str    the value to truncate (e.g. "-2.898983455E20")
      * @param maxLen the maximum number of characters in the returned string
-     * @return a truncation no longer then maxLen (e.g. "-2.8E20" for maxLen=7).
+     * @return a truncation no longer than maxLen (e.g. "-2.8E20" for maxLen=7).
      */
     fun sizeTruncate(str: String, maxLen: Int): String {
         if (maxLen == LEN_UNLIMITED) {

--- a/app/src/main/java/net/youapps/calcyou/ui/CalculatorScreen.kt
+++ b/app/src/main/java/net/youapps/calcyou/ui/CalculatorScreen.kt
@@ -37,6 +37,7 @@ fun CalculatorScreen(
                 modifier = Modifier
                     .padding(8.dp)
                     .fillMaxWidth()
+                    .then(modifier)
             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     SideKeypadHorizontal(


### PR DESCRIPTION
- Correct 'no longer then' -> 'no longer than' in sizeTruncate docs\n- Apply the modifier parameter in landscape orientation of CalculatorScreen to match portrait behavior